### PR TITLE
Update ninterp to 0.11

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -38,7 +38,7 @@ itertools = { version = "0.15.0" }
 kdam = "0.6.3"
 log = "0.4.28"
 ndarray = "=0.17.2" # forces correct transitive dependency on ndarray by ninterp 0.8.0
-ninterp = "0.10.0"
+ninterp = "0.11.0"
 ordered-float = { version = "5.1.0", features = ["serde"] }
 ordered_hash_map = { version = "0.6.0", features = ["serde"] }
 ort = { version = "=2.0.0-rc.13", default-features = false, features = ["std", "ndarray", "copy-dylibs", "download-binaries", "tls-native"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -38,7 +38,7 @@ itertools = { version = "0.15.0" }
 kdam = "0.6.3"
 log = "0.4.28"
 ndarray = "=0.17.2" # forces correct transitive dependency on ndarray by ninterp 0.8.0
-ninterp = "0.9.1"
+ninterp = "0.10.0"
 ordered-float = { version = "5.1.0", features = ["serde"] }
 ordered_hash_map = { version = "0.6.0", features = ["serde"] }
 ort = { version = "=2.0.0-rc.13", default-features = false, features = ["std", "ndarray", "copy-dylibs", "download-binaries", "tls-native"] }

--- a/rust/routee-compass-powertrain/src/model/prediction/interpolation/interpolation_model.rs
+++ b/rust/routee-compass-powertrain/src/model/prediction/interpolation/interpolation_model.rs
@@ -86,31 +86,25 @@ impl InterpolationModel {
             1 => {
                 let grid_0 = grid[0].clone();
                 let values = Self::build_values_1d(model.as_ref(), &grid_0)?;
-                let interp =
-                    Interp1D::new(grid_0, values, strategy::Linear.into(), Extrapolate::Clamp)
-                        .map_err(|e| {
-                            TraversalModelError::TraversalModelFailure(format!(
-                                "Failed to validate 1D interpolation model: {e}"
-                            ))
-                        })?;
+                let interp = Interp1D::new(grid_0, values, strategy::Linear, Extrapolate::Clamp)
+                    .map_err(|e| {
+                        TraversalModelError::TraversalModelFailure(format!(
+                            "Failed to validate 1D interpolation model: {e}"
+                        ))
+                    })?;
                 interp.into()
             }
             2 => {
                 let grid_0 = grid[0].clone();
                 let grid_1 = grid[1].clone();
                 let values = Self::build_values_2d(model.as_ref(), &grid_0, &grid_1)?;
-                let interp = Interp2D::new(
-                    grid_0,
-                    grid_1,
-                    values,
-                    strategy::Linear.into(),
-                    Extrapolate::Clamp,
-                )
-                .map_err(|e| {
-                    TraversalModelError::TraversalModelFailure(format!(
-                        "Failed to validate 2D interpolation model: {e}"
-                    ))
-                })?;
+                let interp =
+                    Interp2D::new(grid_0, grid_1, values, strategy::Linear, Extrapolate::Clamp)
+                        .map_err(|e| {
+                            TraversalModelError::TraversalModelFailure(format!(
+                                "Failed to validate 2D interpolation model: {e}"
+                            ))
+                        })?;
                 interp.into()
             }
             3 => {
@@ -123,7 +117,7 @@ impl InterpolationModel {
                     grid_1,
                     grid_2,
                     values,
-                    strategy::Linear.into(),
+                    strategy::Linear,
                     Extrapolate::Clamp,
                 )
                 .map_err(|e| {
@@ -135,13 +129,12 @@ impl InterpolationModel {
             }
             _ => {
                 let values = Self::build_values_nd(model.as_ref(), &grid)?;
-                let interp =
-                    InterpND::new(grid, values, strategy::Linear.into(), Extrapolate::Clamp)
-                        .map_err(|e| {
-                            TraversalModelError::TraversalModelFailure(format!(
-                                "Failed to validate N-D interpolation model: {e}"
-                            ))
-                        })?;
+                let interp = InterpND::new(grid, values, strategy::Linear, Extrapolate::Clamp)
+                    .map_err(|e| {
+                        TraversalModelError::TraversalModelFailure(format!(
+                            "Failed to validate N-D interpolation model: {e}"
+                        ))
+                    })?;
                 interp.into()
             }
         };

--- a/rust/routee-compass-powertrain/src/model/prediction/interpolation/interpolation_model.rs
+++ b/rust/routee-compass-powertrain/src/model/prediction/interpolation/interpolation_model.rs
@@ -4,34 +4,15 @@ use crate::model::prediction::{
     smartcore::SmartcoreModel,
 };
 use itertools::Itertools;
-use ndarray::{Array1, Array2, Array3, ArrayD, IxDyn};
+use ninterp::ndarray::{Array1, Array2, Array3, ArrayD, IxDyn};
 use ninterp::prelude::*;
 use routee_compass_core::model::{
     state::InputFeature, traversal::TraversalModelError, unit::EnergyRateUnit,
 };
 use std::{collections::HashMap, path::Path};
 
-/// Enum to hold different interpolator types based on dimensionality
-enum InterpolatorVariant {
-    One(Interp1DOwned<f64, strategy::Linear>),
-    Two(Interp2DOwned<f64, strategy::Linear>),
-    Three(Interp3DOwned<f64, strategy::Linear>),
-    N(InterpNDOwned<f64, strategy::Linear>),
-}
-
-impl InterpolatorVariant {
-    fn interpolate(&self, point: &[f64]) -> Result<f64, ninterp::error::InterpolateError> {
-        match self {
-            InterpolatorVariant::One(interp) => interp.interpolate(point),
-            InterpolatorVariant::Two(interp) => interp.interpolate(point),
-            InterpolatorVariant::Three(interp) => interp.interpolate(point),
-            InterpolatorVariant::N(interp) => interp.interpolate(point),
-        }
-    }
-}
-
 pub struct InterpolationModel {
-    interpolator: InterpolatorVariant,
+    interpolator: InterpolatorEnum<f64>,
     energy_rate_unit: EnergyRateUnit,
 }
 
@@ -82,7 +63,7 @@ impl InterpolationModel {
         };
 
         // Build the grid for all features
-        let mut grid: Vec<ndarray::Array1<f64>> = Vec::new();
+        let mut grid: Vec<Array1<f64>> = Vec::new();
 
         for input_feature in input_features.iter() {
             let feature_name = input_feature.name();
@@ -92,7 +73,7 @@ impl InterpolationModel {
                 ))
             })?;
 
-            let feature_grid = ndarray::Array1::from_vec(linspace(
+            let feature_grid = Array1::from_vec(linspace(
                 feature_bounds.lower_bound,
                 feature_bounds.upper_bound,
                 feature_bounds.num_bins,
@@ -105,26 +86,32 @@ impl InterpolationModel {
             1 => {
                 let grid_0 = grid[0].clone();
                 let values = Self::build_values_1d(model.as_ref(), &grid_0)?;
-                let interp = Interp1D::new(grid_0, values, strategy::Linear, Extrapolate::Clamp)
-                    .map_err(|e| {
-                        TraversalModelError::TraversalModelFailure(format!(
-                            "Failed to validate 1D interpolation model: {e}"
-                        ))
-                    })?;
-                InterpolatorVariant::One(interp)
+                let interp =
+                    Interp1D::new(grid_0, values, strategy::Linear.into(), Extrapolate::Clamp)
+                        .map_err(|e| {
+                            TraversalModelError::TraversalModelFailure(format!(
+                                "Failed to validate 1D interpolation model: {e}"
+                            ))
+                        })?;
+                interp.into()
             }
             2 => {
                 let grid_0 = grid[0].clone();
                 let grid_1 = grid[1].clone();
                 let values = Self::build_values_2d(model.as_ref(), &grid_0, &grid_1)?;
-                let interp =
-                    Interp2D::new(grid_0, grid_1, values, strategy::Linear, Extrapolate::Clamp)
-                        .map_err(|e| {
-                            TraversalModelError::TraversalModelFailure(format!(
-                                "Failed to validate 2D interpolation model: {e}"
-                            ))
-                        })?;
-                InterpolatorVariant::Two(interp)
+                let interp = Interp2D::new(
+                    grid_0,
+                    grid_1,
+                    values,
+                    strategy::Linear.into(),
+                    Extrapolate::Clamp,
+                )
+                .map_err(|e| {
+                    TraversalModelError::TraversalModelFailure(format!(
+                        "Failed to validate 2D interpolation model: {e}"
+                    ))
+                })?;
+                interp.into()
             }
             3 => {
                 let grid_0 = grid[0].clone();
@@ -136,7 +123,7 @@ impl InterpolationModel {
                     grid_1,
                     grid_2,
                     values,
-                    strategy::Linear,
+                    strategy::Linear.into(),
                     Extrapolate::Clamp,
                 )
                 .map_err(|e| {
@@ -144,17 +131,18 @@ impl InterpolationModel {
                         "Failed to validate 3D interpolation model: {e}"
                     ))
                 })?;
-                InterpolatorVariant::Three(interp)
+                interp.into()
             }
             _ => {
                 let values = Self::build_values_nd(model.as_ref(), &grid)?;
-                let interp = InterpND::new(grid, values, strategy::Linear, Extrapolate::Clamp)
-                    .map_err(|e| {
-                        TraversalModelError::TraversalModelFailure(format!(
-                            "Failed to validate N-D interpolation model: {e}"
-                        ))
-                    })?;
-                InterpolatorVariant::N(interp)
+                let interp =
+                    InterpND::new(grid, values, strategy::Linear.into(), Extrapolate::Clamp)
+                        .map_err(|e| {
+                            TraversalModelError::TraversalModelFailure(format!(
+                                "Failed to validate N-D interpolation model: {e}"
+                            ))
+                        })?;
+                interp.into()
             }
         };
 


### PR DESCRIPTION
Made an update to ninterp, this keeps you at the state of the art. I also updated the interpolation code to take advantage of `InterpolatorEnum`, an enum directly from ninterp that does the same thing `InterpolatorVariant` did.

I ran the rust & python pixi checks and everything looked green!