### PR TITLE
bump actions/checkout

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -15,7 +15,7 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - uses: conda-incubator/setup-miniconda@v4
         with:
@@ -42,7 +42,7 @@ jobs:
           jupyter-book build .
 
       - name: Checkout benchmark results
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           ref: bench
           path: bench_checkout

--- a/.github/workflows/python-build-test.yaml
+++ b/.github/workflows/python-build-test.yaml
@@ -26,7 +26,7 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -33,7 +33,7 @@ jobs:
 
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: set up python
         uses: actions/setup-python@v6

--- a/.github/workflows/rust-bench.yaml
+++ b/.github/workflows/rust-bench.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Run benchmark with criterion
         working-directory: ./rust

--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Rust
         # Toolchain version and components come from rust-toolchain.toml so that

--- a/.github/workflows/rust-release.yaml
+++ b/.github/workflows/rust-release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
bumps actions/checkout from 6 to 6.0.2. was originally set up as a dependabot PR, this replaces the failed PR starting from /main @ 2026-08-27.